### PR TITLE
environment variables are now prefixed with TF_VAR_

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy it to the final directory:
 
 Try the example:
 
-	export VULTR_API_KEY=TODO_SET_TO_YOUR_API_KEY
+	export TF_VAR_VULTR_API_KEY=TODO_SET_TO_YOUR_API_KEY
 	cd example
 	terraform plan
 	terraform apply

--- a/example/example.tf
+++ b/example/example.tf
@@ -1,5 +1,5 @@
 #provider "vultr" {
-#	api_key = "TODO_SET_TO_YOUR_API_KEY__OR__THE_VULTR_API_KEY_ENV_VARIABLE"
+#	api_key = "TODO_SET_TO_YOUR_API_KEY__OR__THE_TF_VAR_VULTR_API_KEY_ENV_VARIABLE"
 #}
 
 resource "vultr_ssh_key" "example" {


### PR DESCRIPTION
Instead of VULTR_API_KEY it has to be TF_VAR_VULTR_API_KEY.

https://github.com/Capgemini/Apollo/issues/141

Actually, I don't think this is correct.
